### PR TITLE
Role and RoleBinding objects are namespaced.

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKind.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKind.java
@@ -54,8 +54,8 @@ public class KubernetesKind {
   public static KubernetesKind POD_SECURITY_POLICY = new KubernetesKind("podSecurityPolicy");
   public static KubernetesKind POD_DISRUPTION_BUDGET = new KubernetesKind("podDisruptionBudget");
   public static KubernetesKind REPLICA_SET = new KubernetesKind("replicaSet", "rs", true, true);
-  public static KubernetesKind ROLE = new KubernetesKind("role", false);
-  public static KubernetesKind ROLE_BINDING = new KubernetesKind("roleBinding", false);
+  public static KubernetesKind ROLE = new KubernetesKind("role", true);
+  public static KubernetesKind ROLE_BINDING = new KubernetesKind("roleBinding", true);
   public static KubernetesKind SECRET = new KubernetesKind("secret");
   public static KubernetesKind SERVICE = new KubernetesKind("service", "svc", true, true);
   public static KubernetesKind SERVICE_ACCOUNT = new KubernetesKind("serviceAccount", "sa");


### PR DESCRIPTION
It was recently discovered that some of our deployments were broken due to Role and RoleBinding objects not being resolvable in clouddriver. This appears to be due to a fix in clouddriver outlined in #2984. The fix will prevent caching of cluster-scoped objects in a namespace.

Since we have marked Role and RoleBinding as not namespaced, they are being ignored by the caching agents, as outlined in the pull request above.

This PR marks the resources as namespaced, as it is outlined in the k8s API documentation that they can be. This should mean the resources will pass the check in #2984,  allowing them to be cached going forward.