### PR TITLE
Statefulset Partition roll out support

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifest.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifest.java
@@ -251,6 +251,22 @@ public class KubernetesManifest extends HashMap<String, Object> {
   }
 
   @JsonIgnore
+  public Integer getObservedGeneration() {
+    Object statusObj = getStatus();
+    if (!(statusObj instanceof Map)) {
+      throw new IllegalStateException("Expected status to be a Map but was actually a " + statusObj.getClass());
+    }
+    Map<String, Object> status = (Map<String, Object>) statusObj;
+
+    Object observedGenObj = status.get("observedGeneration");
+
+    if (!(observedGenObj instanceof Integer)) {
+      throw new IllegalStateException("Expected status.observedGeneration to be an Integer but was actually a " + observedGenObj.getClass());
+    }
+    return (Integer) observedGenObj;
+  }
+
+  @JsonIgnore
   public String getFullResourceName() {
     return getFullResourceName(getKind(), getName());
   }
@@ -259,6 +275,7 @@ public class KubernetesManifest extends HashMap<String, Object> {
     return String.join(" ", kind.toString(), name);
   }
 
+  @JsonIgnore
   public boolean isNewerThanObservedGeneration() {
     Object generationObj = getMetadata().get("generation");
     if (generationObj == null) {
@@ -271,8 +288,13 @@ public class KubernetesManifest extends HashMap<String, Object> {
 
     Integer generation = (Integer) generationObj;
 
-    Integer observedGeneration = ((Map<String, Integer>) getStatus()).get("observedGeneration");
-    return !(observedGeneration == null || (generation > observedGeneration));
+    Integer observedGeneration = getObservedGeneration();
+
+    if (observedGeneration == null) {
+      return false;
+    }
+
+    return !(generation > observedGeneration);
   }
 
   /*

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifest.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifest.java
@@ -256,6 +256,7 @@ public class KubernetesManifest extends HashMap<String, Object> {
     if (!(statusObj instanceof Map)) {
       throw new IllegalStateException("Expected status to be a Map but was actually a " + statusObj.getClass());
     }
+
     Map<String, Object> status = (Map<String, Object>) statusObj;
 
     Object observedGenObj = status.get("observedGeneration");
@@ -289,10 +290,6 @@ public class KubernetesManifest extends HashMap<String, Object> {
   public boolean isNewerThanObservedGeneration() {
     Double generation = getGeneration();
     Double observedGeneration = getObservedGeneration();
-
-    if (observedGeneration == null || generation == null || generation < 1.0) {
-      return false;
-    }
 
     return generation > observedGeneration;
   }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifest.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifest.java
@@ -267,6 +267,16 @@ public class KubernetesManifest extends HashMap<String, Object> {
   }
 
   @JsonIgnore
+  public Integer getGeneration() {
+    Object generationObj = getMetadata().get("generation");
+
+    if (!(generationObj instanceof Integer)) {
+      throw new IllegalStateException("Expected metadata.generation to be an Integer but was actually a " + generationObj.getClass());
+    }
+    return (Integer) generationObj;
+  }
+
+  @JsonIgnore
   public String getFullResourceName() {
     return getFullResourceName(getKind(), getName());
   }
@@ -277,24 +287,14 @@ public class KubernetesManifest extends HashMap<String, Object> {
 
   @JsonIgnore
   public boolean isNewerThanObservedGeneration() {
-    Object generationObj = getMetadata().get("generation");
-    if (generationObj == null) {
-      return false;
-    }
-
-    if (!(generationObj instanceof Integer)) {
-      throw new IllegalStateException("Expected metadata.generation to be an Integer but was actually a " + generationObj.getClass());
-    }
-
-    Integer generation = (Integer) generationObj;
-
+    Integer generation = getGeneration();
     Integer observedGeneration = getObservedGeneration();
 
-    if (observedGeneration == null) {
+    if (observedGeneration == null || generation == null) {
       return false;
     }
 
-    return !(generation > observedGeneration);
+    return generation > observedGeneration;
   }
 
   /*

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifest.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifest.java
@@ -251,7 +251,7 @@ public class KubernetesManifest extends HashMap<String, Object> {
   }
 
   @JsonIgnore
-  public Integer getObservedGeneration() {
+  public Double getObservedGeneration() {
     Object statusObj = getStatus();
     if (!(statusObj instanceof Map)) {
       throw new IllegalStateException("Expected status to be a Map but was actually a " + statusObj.getClass());
@@ -260,20 +260,20 @@ public class KubernetesManifest extends HashMap<String, Object> {
 
     Object observedGenObj = status.get("observedGeneration");
 
-    if (!(observedGenObj instanceof Integer)) {
-      throw new IllegalStateException("Expected status.observedGeneration to be an Integer but was actually a " + observedGenObj.getClass());
+    if (!(observedGenObj instanceof Double)) {
+      throw new IllegalStateException("Expected status.observedGeneration to be an Double but was actually a " + observedGenObj.getClass());
     }
-    return (Integer) observedGenObj;
+    return (Double) observedGenObj;
   }
 
   @JsonIgnore
-  public Integer getGeneration() {
+  public Double getGeneration() {
     Object generationObj = getMetadata().get("generation");
 
-    if (!(generationObj instanceof Integer)) {
-      throw new IllegalStateException("Expected metadata.generation to be an Integer but was actually a " + generationObj.getClass());
+    if (!(generationObj instanceof Double)) {
+      throw new IllegalStateException("Expected metadata.generation to be an Double but was actually a " + generationObj.getClass());
     }
-    return (Integer) generationObj;
+    return (Double) generationObj;
   }
 
   @JsonIgnore
@@ -287,10 +287,10 @@ public class KubernetesManifest extends HashMap<String, Object> {
 
   @JsonIgnore
   public boolean isNewerThanObservedGeneration() {
-    Integer generation = getGeneration();
-    Integer observedGeneration = getObservedGeneration();
+    Double generation = getGeneration();
+    Double observedGeneration = getObservedGeneration();
 
-    if (observedGeneration == null || generation == null) {
+    if (observedGeneration == null || generation == null || generation < 1.0) {
       return false;
     }
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifest.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifest.java
@@ -260,9 +260,19 @@ public class KubernetesManifest extends HashMap<String, Object> {
   }
 
   public boolean isNewerThanObservedGeneration() {
-    Integer generation = (Integer) getMetadata().get("generation");
+    Object generationObj = getMetadata().get("generation");
+    if (generationObj == null) {
+      return false;
+    }
+
+    if (!(generationObj instanceof Integer)) {
+      throw new IllegalStateException("Expected metadata.generation to be an Integer but was actually a " + generationObj.getClass());
+    }
+
+    Integer generation = (Integer) generationObj;
+
     Integer observedGeneration = ((Map<String, Integer>) getStatus()).get("observedGeneration");
-    return !(observedGeneration == null || (generation != null && generation > observedGeneration));
+    return !(observedGeneration == null || (generation > observedGeneration));
   }
 
   /*

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifest.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifest.java
@@ -262,8 +262,9 @@ public class KubernetesManifest extends HashMap<String, Object> {
   public boolean isNewerThanObservedGeneration() {
     Integer generation = (Integer) getMetadata().get("generation");
     Integer observedGeneration = ((Map<String, Integer>) getStatus()).get("observedGeneration");
-    return (observedGeneration == null || (generation != null && generation > observedGeneration));
+    return !(observedGeneration == null || (generation != null && generation > observedGeneration));
   }
+
   /*
    * The reasoning behind removing metadata for comparison is that it shouldn't affect the runtime behavior
    * of the resource we are creating.

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifest.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifest.java
@@ -161,7 +161,7 @@ public class KubernetesManifest extends HashMap<String, Object> {
   @JsonIgnore
   public Double getReplicas() {
     if (!containsKey("spec")) {
-      return null; 
+      return null;
     }
 
     Map<String, Object> spec = (Map<String, Object>) get("spec");
@@ -181,7 +181,7 @@ public class KubernetesManifest extends HashMap<String, Object> {
     Map<String, Object> spec = (Map<String, Object>) get("spec");
     if (!spec.containsKey("replicas")) {
       return;
-    } 
+    }
     spec.put("replicas", replicas);
   }
 
@@ -260,15 +260,9 @@ public class KubernetesManifest extends HashMap<String, Object> {
   }
 
   public boolean isNewerThanObservedGeneration() {
-    try {
-      Long generation = (Long) getMetadata().get("generation");
-      Long observedGeneration = ((Map<String, Long>) getStatus()).get("observedGeneration");
-      if (observedGeneration == null || (generation != null && generation > observedGeneration)) {
-        return false;
-      }
-    } catch (ClassCastException e) {
-    }
-    return true;
+    Integer generation = (Integer) getMetadata().get("generation");
+    Integer observedGeneration = ((Map<String, Integer>) getStatus()).get("observedGeneration");
+    return (observedGeneration == null || (generation != null && generation > observedGeneration));
   }
   /*
    * The reasoning behind removing metadata for comparison is that it shouldn't affect the runtime behavior

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDaemonSetHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDaemonSetHandler.java
@@ -80,7 +80,7 @@ public class KubernetesDaemonSetHandler extends KubernetesHandler implements
 
   @Override
   public Status status(KubernetesManifest manifest) {
-    if (!manifest.isNewerThanObservedGeneration()) {
+    if (manifest.isNewerThanObservedGeneration()) {
       return (new Status()).unknown();
     }
     V1beta2DaemonSet v1beta2DaemonSet = KubernetesCacheDataConverter.getResource(manifest, V1beta2DaemonSet.class);

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDeploymentHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDeploymentHandler.java
@@ -79,7 +79,7 @@ public class KubernetesDeploymentHandler extends KubernetesHandler implements
     if (manifest.getApiVersion().equals(EXTENSIONS_V1BETA1)
         || manifest.getApiVersion().equals(APPS_V1BETA1)
         || manifest.getApiVersion().equals(APPS_V1BETA2)) {
-      if (!manifest.isNewerThanObservedGeneration()) {
+      if (manifest.isNewerThanObservedGeneration()) {
         return (new Status()).unknown();
       }
       V1beta2Deployment appsV1beta2Deployment = KubernetesCacheDataConverter.getResource(manifest, V1beta2Deployment.class);

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandler.java
@@ -90,7 +90,7 @@ public class KubernetesStatefulSetHandler extends KubernetesHandler implements
 
   @Override
   public Status status(KubernetesManifest manifest) {
-    if (!manifest.isNewerThanObservedGeneration()) {
+    if (manifest.isNewerThanObservedGeneration()) {
       return (new Status()).unknown();
     }
     V1beta2StatefulSet v1beta2StatefulSet = KubernetesCacheDataConverter.getResource(manifest, V1beta2StatefulSet.class);

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandler.java
@@ -150,7 +150,8 @@ public class KubernetesStatefulSetHandler extends KubernetesHandler implements
     if (updateType.equalsIgnoreCase("rollingupdate")) {
       Integer replicas = status.getReplicas();
       Integer updated = status.getUpdatedReplicas();
-      if (replicas != null && rollingUpdate.getPartition() != null && (updated < (replicas - rollingUpdate.getPartition()))) {
+      Integer partition = rollingUpdate.getPartition();
+      if (replicas != null && partition != null && (updated < (replicas - partition))) {
         return result.unstable("Waiting for partitioned roll out to finish");
       }
       result.setStable(new Status.Condition(true,"Partitioned roll out complete"));

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandler.java
@@ -27,6 +27,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpi
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
+import io.kubernetes.client.models.V1beta2RollingUpdateStatefulSetStrategy;
 import io.kubernetes.client.models.V1beta2StatefulSet;
 import io.kubernetes.client.models.V1beta2StatefulSetStatus;
 import org.apache.commons.lang3.StringUtils;
@@ -142,6 +143,18 @@ public class KubernetesStatefulSetHandler extends KubernetesHandler implements
     existing = status.getReadyReplicas();
     if (existing == null || (desiredReplicas != null && desiredReplicas > existing)) {
       return result.unstable("Waiting for all updated replicas to be ready");
+    }
+
+    String updateType = statefulSet.getSpec().getUpdateStrategy().getType();
+    V1beta2RollingUpdateStatefulSetStrategy rollingUpdate = statefulSet.getSpec().getUpdateStrategy().getRollingUpdate();
+    if (updateType.equalsIgnoreCase("rollingupdate")) {
+      Integer replicas = status.getReplicas();
+      Integer updated = status.getUpdatedReplicas();
+      if (replicas != null && rollingUpdate.getPartition() != null && (updated < (replicas - rollingUpdate.getPartition()))) {
+        return result.unstable("Waiting for partitioned roll out to finish");
+      }
+      result.setStable(new Status.Condition(true,"Partitioned roll out complete"));
+      return result;
     }
 
     return result;

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesManifestSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesManifestSpec.groovy
@@ -43,6 +43,7 @@ kind: $KIND
 metadata:
   name: $NAME
   namespace: $NAMESPACE
+  generation: 1
 spec:
   template:
     metadata:
@@ -80,5 +81,29 @@ spec:
     "service abc"    || KubernetesKind.SERVICE     | "abc"
     "SERVICE abc"    || KubernetesKind.SERVICE     | "abc"
     "ingress abc"    || KubernetesKind.INGRESS     | "abc"
+  }
+
+  void "correctly reads observedGeneration from status"() {
+    when:
+    def statusYaml = """
+status:
+ observedGeneration: 1
+"""
+    KubernetesManifest manifest = stringToManifest(BASIC_REPLICA_SET + statusYaml)
+
+    then:
+    manifest.getObservedGeneration() == 1
+  }
+
+  void "correctly determines isNewerThanObservedGeneration"() {
+    when:
+    def statusYaml = """
+status:
+ observedGeneration: 2
+"""
+    KubernetesManifest manifest = stringToManifest(BASIC_REPLICA_SET + statusYaml)
+
+    then:
+    manifest.isNewerThanObservedGeneration()
   }
 }

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesManifestSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesManifestSpec.groovy
@@ -22,10 +22,7 @@ import com.google.gson.Gson
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest
-import groovy.json.JsonSlurper
 import groovy.text.SimpleTemplateEngine
-import org.yaml.snakeyaml.Yaml
-import org.yaml.snakeyaml.constructor.SafeConstructor
 import spock.lang.Specification
 import spock.lang.Unroll
 

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesManifestSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesManifestSpec.groovy
@@ -37,7 +37,7 @@ class KubernetesManifestSpec extends Specification {
   def KEY = "hi"
   def VALUE = "there"
 
-  String basicJson() {
+  String basicManifestSource() {
     def sourceJson = KubernetesManifest.class.getResource("manifest.json").getText("utf-8")
     def templateEngine = new SimpleTemplateEngine()
     def binding = [
@@ -59,7 +59,7 @@ class KubernetesManifestSpec extends Specification {
 
   void "correctly reads fields from basic manifest definition"() {
     when:
-    def testPayload =  gsonObj.fromJson(basicJson(), Object)
+    def testPayload =  gsonObj.fromJson(basicManifestSource(), Object)
     KubernetesManifest manifest = objectToManifest(testPayload)
 
     then:
@@ -97,7 +97,7 @@ class KubernetesManifestSpec extends Specification {
 """
 
     def testStatusJson = gsonObj.fromJson(statusJson, Object)
-    def testPayload = gsonObj.fromJson(basicJson(), Object)
+    def testPayload = gsonObj.fromJson(basicManifestSource(), Object)
     KubernetesManifest manifest = objectToManifest(testPayload << testStatusJson)
 
     then:
@@ -106,7 +106,7 @@ class KubernetesManifestSpec extends Specification {
 
   void "correctly reads generation from manifest"() {
     when:
-    def testPayload =  gsonObj.fromJson(basicJson(), Object)
+    def testPayload =  gsonObj.fromJson(basicManifestSource(), Object)
     KubernetesManifest manifest = objectToManifest(testPayload)
 
     then:
@@ -124,7 +124,7 @@ class KubernetesManifestSpec extends Specification {
 """
 
     def testStatusJson = gsonObj.fromJson(statusJson, Object)
-    def testPayload = gsonObj.fromJson(basicJson(), Object)
+    def testPayload = gsonObj.fromJson(basicManifestSource(), Object)
     KubernetesManifest manifest = objectToManifest(testPayload << testStatusJson)
     then:
     manifest.isNewerThanObservedGeneration()

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesManifestSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesManifestSpec.groovy
@@ -53,14 +53,14 @@ class KubernetesManifestSpec extends Specification {
   }
 
 
-  KubernetesManifest stringToManifest(Object input) {
+  KubernetesManifest objectToManifest(Object input) {
     return objectMapper.convertValue(input, KubernetesManifest)
   }
 
   void "correctly reads fields from basic manifest definition"() {
     when:
     def testPayload =  gsonObj.fromJson(basicJson(), Object)
-    KubernetesManifest manifest = stringToManifest(testPayload)
+    KubernetesManifest manifest = objectToManifest(testPayload)
 
     then:
     manifest.getName() == NAME
@@ -98,7 +98,7 @@ class KubernetesManifestSpec extends Specification {
 
     def testStatusJson = gsonObj.fromJson(statusJson, Object)
     def testPayload = gsonObj.fromJson(basicJson(), Object)
-    KubernetesManifest manifest = stringToManifest(testPayload << testStatusJson)
+    KubernetesManifest manifest = objectToManifest(testPayload << testStatusJson)
 
     then:
     manifest.getObservedGeneration() == 1
@@ -107,7 +107,7 @@ class KubernetesManifestSpec extends Specification {
   void "correctly reads generation from manifest"() {
     when:
     def testPayload =  gsonObj.fromJson(basicJson(), Object)
-    KubernetesManifest manifest = stringToManifest(testPayload)
+    KubernetesManifest manifest = objectToManifest(testPayload)
 
     then:
     manifest.getGeneration() == 3
@@ -125,7 +125,7 @@ class KubernetesManifestSpec extends Specification {
 
     def testStatusJson = gsonObj.fromJson(statusJson, Object)
     def testPayload = gsonObj.fromJson(basicJson(), Object)
-    KubernetesManifest manifest = stringToManifest(testPayload << testStatusJson)
+    KubernetesManifest manifest = objectToManifest(testPayload << testStatusJson)
     then:
     manifest.isNewerThanObservedGeneration()
   }

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesManifestSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesManifestSpec.groovy
@@ -95,15 +95,23 @@ status:
     manifest.getObservedGeneration() == 1
   }
 
+  void "correctly reads generation from manifest"() {
+    when:
+    KubernetesManifest manifest = stringToManifest(BASIC_REPLICA_SET)
+
+    then:
+    manifest.getGeneration() == 1
+  }
+
   void "correctly determines isNewerThanObservedGeneration"() {
     when:
     def statusYaml = """
 status:
- observedGeneration: 2
+ observedGeneration: 1
 """
     KubernetesManifest manifest = stringToManifest(BASIC_REPLICA_SET + statusYaml)
 
     then:
-    manifest.isNewerThanObservedGeneration()
+    !manifest.isNewerThanObservedGeneration()
   }
 }

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandlerSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandlerSpec.groovy
@@ -96,17 +96,13 @@ status:
     def statefulSetDeployer = new KubernetesStatefulSetHandler()
     statefulSetDeployer.versioned() >> true
     statefulSetDeployer.kind() >> KIND
-    def versionedArtifactConverterMock = Mock(KubernetesVersionedArtifactConverter)
-    versionedArtifactConverterMock.getDeployedName(_) >> "$NAME-$VERSION"
-    versionedArtifactConverterMock.toArtifact(_, _, _) >> new Artifact()
+
     def registry = new KubernetesResourcePropertyRegistry(Collections.singletonList(statefulSetDeployer),
       new KubernetesSpinnakerKindMap())
 
     NamerRegistry.lookup().withProvider(KubernetesCloudProvider.ID)
       .withAccount(ACCOUNT)
       .setNamer(KubernetesManifest.class, new KubernetesManifestNamer())
-
-    registry.get("any", KubernetesKind.STATEFUL_SET).versionedConverter = versionedArtifactConverterMock
 
     def deployOp = new KubernetesDeployManifestOperation(deployDescription, registry, null)
 

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandlerSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandlerSpec.groovy
@@ -94,7 +94,7 @@ status:
     credentials.deploy(_, _) >> null
 
     def statefulSetDeployer = new KubernetesStatefulSetHandler()
-    statefulSetDeployer.versioned() >> true
+    statefulSetDeployer.versioned() >> false
     statefulSetDeployer.kind() >> KIND
 
     def registry = new KubernetesResourcePropertyRegistry(Collections.singletonList(statefulSetDeployer),

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandlerSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandlerSpec.groovy
@@ -1,0 +1,135 @@
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact.ArtifactTypes
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact.KubernetesVersionedArtifactConverter
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesResourcePropertyRegistry
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesDeployManifestDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.names.KubernetesManifestNamer
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.manifest.KubernetesDeployManifestOperation
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials
+import com.netflix.spinnaker.clouddriver.model.Manifest
+import com.netflix.spinnaker.clouddriver.names.NamerRegistry
+import com.netflix.spinnaker.kork.artifacts.model.Artifact
+import com.netflix.spinnaker.moniker.Moniker
+import org.yaml.snakeyaml.Yaml
+import org.yaml.snakeyaml.constructor.SafeConstructor
+import spock.lang.Specification
+
+import java.util.concurrent.locks.Condition
+
+class KubernetesStatefulSetHandlerSpec extends Specification {
+  def objectMapper = new ObjectMapper()
+  def yaml = new Yaml(new SafeConstructor())
+  def handler = new KubernetesStatefulSetHandler()
+
+  def IMAGE = "gcr.io/project/image"
+  def ACCOUNT = "my-account"
+  def CLUSTER_SIZE = 5
+  def VERSION = "version"
+  def NAMESPACE = "my-namespace"
+  def NAME = "my-name"
+  def KIND = KubernetesKind.STATEFUL_SET
+
+  def STATEFUL_SET = """
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: $NAME
+  namespace: $NAMESPACE
+  labels:
+    app: $NAME
+    service: $NAME
+spec:
+  serviceName: $NAME-service
+  podManagementPolicy: Parallel
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      partition: $CLUSTER_SIZE
+  replicas: $CLUSTER_SIZE
+  selector:
+    matchLabels:
+      app: $NAME
+      cluster: $NAME
+  template:
+    spec:    
+      containers:
+      - name: $NAME
+        image: $IMAGE
+        imagePullPolicy: Always
+status:
+ availableReplicas: $CLUSTER_SIZE
+ observedGeneration: $CLUSTER_SIZE
+ currentReplicas: $CLUSTER_SIZE
+ readyReplicas: $CLUSTER_SIZE
+ replicas: $CLUSTER_SIZE
+ updatedReplicas: $CLUSTER_SIZE
+ currentRevision: $NAME-$VERSION
+ updateRevision: $NAME-$VERSION
+"""
+
+  def setupSpec() {
+    TaskRepository.threadLocalTask.set(Mock(Task))
+  }
+
+  KubernetesDeployManifestOperation createMockDeployer(KubernetesV2Credentials credentials, String manifest) {
+    def deployDescription = new KubernetesDeployManifestDescription()
+      .setManifest(stringToManifest(manifest))
+      .setMoniker(new Moniker())
+      .setSource(KubernetesDeployManifestDescription.Source.text)
+
+    def namedCredentialsMock = Mock(KubernetesNamedAccountCredentials)
+    namedCredentialsMock.getCredentials() >> credentials
+    namedCredentialsMock.getName() >> ACCOUNT
+    deployDescription.setCredentials(namedCredentialsMock)
+
+    credentials.deploy(_, _) >> null
+
+    def statefulSetDeployer = new KubernetesStatefulSetHandler()
+    statefulSetDeployer.versioned() >> true
+    statefulSetDeployer.kind() >> KIND
+    def versionedArtifactConverterMock = Mock(KubernetesVersionedArtifactConverter)
+    versionedArtifactConverterMock.getDeployedName(_) >> "$NAME-$VERSION"
+    versionedArtifactConverterMock.toArtifact(_, _, _) >> new Artifact()
+    def registry = new KubernetesResourcePropertyRegistry(Collections.singletonList(statefulSetDeployer),
+      new KubernetesSpinnakerKindMap())
+
+    NamerRegistry.lookup().withProvider(KubernetesCloudProvider.ID)
+      .withAccount(ACCOUNT)
+      .setNamer(KubernetesManifest.class, new KubernetesManifestNamer())
+
+    registry.get("any", KubernetesKind.STATEFUL_SET).versionedConverter = versionedArtifactConverterMock
+
+    def deployOp = new KubernetesDeployManifestOperation(deployDescription, registry, null)
+
+    return deployOp
+  }
+
+  KubernetesManifest stringToManifest(String input) {
+    return objectMapper.convertValue(yaml.load(input), KubernetesManifest)
+  }
+
+  void "check for stable state by default"() {
+    setup:
+    def credentialsMock = Mock(KubernetesV2Credentials)
+    credentialsMock.getDefaultNamespace() >> NAMESPACE
+    def deployOp = createMockDeployer(credentialsMock, STATEFUL_SET)
+    def stable = new Manifest.Status.Condition(state: true, message: null)
+
+    when:
+    def deployResult = deployOp.operate([])
+
+    then:
+    deployResult.manifestNamesByNamespace[NAMESPACE].size() == 1
+    deployResult.manifestNamesByNamespace[NAMESPACE][0] == "$KIND $NAME"
+    handler.status(deployResult.getManifests().first()).stable == stable
+  }
+}

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandlerSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandlerSpec.groovy
@@ -5,8 +5,6 @@ import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact.ArtifactTypes
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact.KubernetesVersionedArtifactConverter
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesResourcePropertyRegistry
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesDeployManifestDescription
@@ -15,15 +13,12 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.Kube
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.names.KubernetesManifestNamer
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.manifest.KubernetesDeployManifestOperation
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials
-import com.netflix.spinnaker.clouddriver.model.Manifest
 import com.netflix.spinnaker.clouddriver.names.NamerRegistry
-import com.netflix.spinnaker.kork.artifacts.model.Artifact
 import com.netflix.spinnaker.moniker.Moniker
 import org.yaml.snakeyaml.Yaml
 import org.yaml.snakeyaml.constructor.SafeConstructor
 import spock.lang.Specification
 
-import java.util.concurrent.locks.Condition
 
 class KubernetesStatefulSetHandlerSpec extends Specification {
   def objectMapper = new ObjectMapper()
@@ -38,12 +33,13 @@ class KubernetesStatefulSetHandlerSpec extends Specification {
   def NAME = "my-name"
   def KIND = KubernetesKind.STATEFUL_SET
 
-  def STATEFUL_SET = """
+  def STATEFUL_SET_BASE = """
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: $NAME
   namespace: $NAMESPACE
+  generation: 1
   labels:
     app: $NAME
     service: $NAME
@@ -65,16 +61,8 @@ spec:
       - name: $NAME
         image: $IMAGE
         imagePullPolicy: Always
-status:
- availableReplicas: $CLUSTER_SIZE
- observedGeneration: $CLUSTER_SIZE
- currentReplicas: $CLUSTER_SIZE
- readyReplicas: $CLUSTER_SIZE
- replicas: $CLUSTER_SIZE
- updatedReplicas: $CLUSTER_SIZE
- currentRevision: $NAME-$VERSION
- updateRevision: $NAME-$VERSION
 """
+
 
   def setupSpec() {
     TaskRepository.threadLocalTask.set(Mock(Task))
@@ -113,19 +101,125 @@ status:
     return objectMapper.convertValue(yaml.load(input), KubernetesManifest)
   }
 
-  void "check for stable state by default"() {
+  def "statefulset stable state is null if generation > observedGeneration"() {
     setup:
+    def statusYaml = """
+status:
+ observedGeneration: 0
+"""
     def credentialsMock = Mock(KubernetesV2Credentials)
     credentialsMock.getDefaultNamespace() >> NAMESPACE
-    def deployOp = createMockDeployer(credentialsMock, STATEFUL_SET)
-    def stable = new Manifest.Status.Condition(state: true, message: null)
+    def deployOp = createMockDeployer(credentialsMock, STATEFUL_SET_BASE + statusYaml)
 
     when:
     def deployResult = deployOp.operate([])
+    def status = handler.status(deployResult.getManifests().first())
 
     then:
-    deployResult.manifestNamesByNamespace[NAMESPACE].size() == 1
-    deployResult.manifestNamesByNamespace[NAMESPACE][0] == "$KIND $NAME"
-    handler.status(deployResult.getManifests().first()).stable == stable
+    status.stable == null
+  }
+
+  def "wait for at least the desired replica count to be met"() {
+    setup:
+    def statusYaml = """
+status:
+ availableReplicas: 0
+ observedGeneration: 1
+ currentReplicas: 0
+ readyReplicas: 0
+ replicas: 0
+ updatedReplicas: 0
+ currentRevision: $NAME-$VERSION
+ updateRevision: $NAME-$VERSION
+"""
+    def credentialsMock = Mock(KubernetesV2Credentials)
+    credentialsMock.getDefaultNamespace() >> NAMESPACE
+    def deployOp = createMockDeployer(credentialsMock, STATEFUL_SET_BASE + statusYaml)
+
+    when:
+    def deployResult = deployOp.operate([])
+    def status = handler.status(deployResult.getManifests().first())
+
+    then:
+    !status.stable.state
+    status.stable.message == "Waiting for at least the desired replica count to be met"
+  }
+
+  def "wait for the updated revision to match the current revision"() {
+    setup:
+    def statusYaml = """
+status:
+ availableReplicas: 0
+ observedGeneration: 1
+ currentReplicas: 0
+ readyReplicas: 0
+ replicas: 5
+ updatedReplicas: 0
+ currentRevision: $NAME-new-my-version
+ updateRevision: $NAME-$VERSION
+"""
+    def credentialsMock = Mock(KubernetesV2Credentials)
+    credentialsMock.getDefaultNamespace() >> NAMESPACE
+    def deployOp = createMockDeployer(credentialsMock, STATEFUL_SET_BASE + statusYaml)
+
+    when:
+    def deployResult = deployOp.operate([])
+    def status = handler.status(deployResult.getManifests().first())
+
+    then:
+    !status.stable.state
+    status.stable.message == "Waiting for the updated revision to match the current revision"
+  }
+
+  def "wait for all updated replicas to be scheduled"() {
+    setup:
+    def statusYaml = """
+status:
+ availableReplicas: 0
+ observedGeneration: 1
+ currentReplicas: 4
+ readyReplicas: 0
+ replicas: 5
+ updatedReplicas: 0
+ currentRevision: $NAME-$VERSION
+ updateRevision: $NAME-$VERSION
+"""
+    def credentialsMock = Mock(KubernetesV2Credentials)
+    credentialsMock.getDefaultNamespace() >> NAMESPACE
+    def deployOp = createMockDeployer(credentialsMock, STATEFUL_SET_BASE + statusYaml)
+
+    when:
+    def deployResult = deployOp.operate([])
+    def status = handler.status(deployResult.getManifests().first())
+
+    then:
+    !status.stable.state
+    status.stable.message == "Waiting for all updated replicas to be scheduled"
+  }
+
+  def "wait for all updated replicas to be ready"() {
+    setup:
+    def statusYaml = """
+status:
+ availableReplicas: 0
+ observedGeneration: 1
+ currentReplicas: 5
+ readyReplicas: 4
+ replicas: 5
+ updatedReplicas: 0
+ currentRevision: $NAME-$VERSION
+ updateRevision: $NAME-$VERSION
+"""
+    def credentialsMock = Mock(KubernetesV2Credentials)
+    credentialsMock.getDefaultNamespace() >> NAMESPACE
+    def deployOp = createMockDeployer(credentialsMock, STATEFUL_SET_BASE + statusYaml)
+
+    when:
+    def deployResult = deployOp.operate([])
+    def status = handler.status(deployResult.getManifests().first())
+
+    then:
+    !status.stable.state
+    status.stable.message == "Waiting for all updated replicas to be ready"
   }
 }

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandlerSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandlerSpec.groovy
@@ -58,7 +58,7 @@ spec:
     return objectMapper.convertValue(yaml.load(input), KubernetesManifest)
   }
 
-  def "statefulset stable state is null if generation > observedGeneration"() {
+  def "statefulset stable state is null if manifest.isNewerThanObservedGeneration()"() {
     when:
     def statusYaml = """
 status:

--- a/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/manifest.json
+++ b/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/manifest.json
@@ -1,0 +1,139 @@
+{
+  "apiVersion": "$api_version",
+  "kind": "$kind",
+  "metadata": {
+    "annotations": {
+      "deployment.kubernetes.io/desired-replicas": "3",
+      "deployment.kubernetes.io/max-replicas": "4",
+      "deployment.kubernetes.io/revision": "3",
+      "$key": "$value",
+      "time": "2018-10-29 15:40:52.062718 -0400 EDT m=+0.047437104"
+    },
+    "creationTimestamp": "2018-10-29T19:40:53Z",
+    "generation": 3,
+    "labels": {
+      "app": "$name-$name",
+      "name": "$name",
+      "pod-template-hash": "2746006312"
+    },
+    "name": "$name",
+    "namespace": "$namespace",
+    "ownerReferences": [
+      {
+        "apiVersion": "extensions/v1beta1",
+        "blockOwnerDeletion": true,
+        "controller": true,
+        "kind": "Deployment",
+        "name": "$name",
+        "uid": "423e3217-dbb1-11e8-bcfd-02ff462358c8"
+      }
+    ],
+    "resourceVersion": "38075718",
+    "selfLink": "/apis/extensions/v1beta1/namespaces/$namespace/replicasets/$name-6c8b44b756",
+    "uid": "8bfb57ad-dbb2-11e8-9989-0efba1451dfa"
+  },
+  "spec": {
+    "replicas": 3,
+    "selector": {
+      "matchLabels": {
+        "app": "$name-$name",
+        "name": "$name",
+        "pod-template-hash": "2746006312"
+      }
+    },
+    "template": {
+      "metadata": {
+        "annotations": {
+          "time": "2018-10-29 15:40:52.062811 -0400 EDT m=+0.047529510",
+          "$key": "$value"
+        },
+        "creationTimestamp": null,
+        "labels": {
+          "app": "$name-$name",
+          "chartVersion": "0.0.6",
+          "name": "$name",
+          "pod-template-hash": "2746006312"
+        }
+      },
+      "spec": {
+        "affinity": {
+          "nodeAffinity": {
+            "requiredDuringSchedulingIgnoredDuringExecution": {
+              "nodeSelectorTerms": [
+                {
+                  "matchExpressions": [
+                    {
+                      "key": "node-role.kubernetes.io/$name",
+                      "operator": "Exists"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "containers": [
+          {
+            "image": "$name/test:0.1",
+            "imagePullPolicy": "IfNotPresent",
+            "livenessProbe": {
+              "failureThreshold": 3,
+              "httpGet": {
+                "path": "/",
+                "port": 5000,
+                "scheme": "HTTP"
+              },
+              "initialDelaySeconds": 20,
+              "periodSeconds": 10,
+              "successThreshold": 1,
+              "timeoutSeconds": 2
+            },
+            "name": "$name",
+            "ports": [
+              {
+                "containerPort": 5000,
+                "name": "http",
+                "protocol": "TCP"
+              }
+            ],
+            "readinessProbe": {
+              "failureThreshold": 3,
+              "httpGet": {
+                "path": "/",
+                "port": 5000,
+                "scheme": "HTTP"
+              },
+              "initialDelaySeconds": 20,
+              "periodSeconds": 10,
+              "successThreshold": 1,
+              "timeoutSeconds": 2
+            },
+            "resources": {},
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File"
+          }
+        ],
+        "dnsPolicy": "ClusterFirst",
+        "restartPolicy": "Always",
+        "schedulerName": "default-scheduler",
+        "securityContext": {},
+        "terminationGracePeriodSeconds": 30,
+        "tolerations": [
+          {
+            "effect": "NoSchedule",
+            "key": "node",
+            "operator": "Equal",
+            "value": "$name"
+          }
+        ]
+      }
+    }
+  },
+  "status": {
+    "availableReplicas": 3,
+    "fullyLabeledReplicas": 3,
+    "observedGeneration": 3,
+    "readyReplicas": 3,
+    "replicas": 3
+  }
+}

--- a/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/statefulsetbase.json
+++ b/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/statefulsetbase.json
@@ -1,0 +1,148 @@
+{
+  "apiVersion": "apps/v1",
+  "kind": "StatefulSet",
+  "metadata": {
+    "annotations": {
+      "artifact.spinnaker.io/location": "$namespace",
+      "artifact.spinnaker.io/name": "$name",
+      "artifact.spinnaker.io/type": "kubernetes/statefulSet",
+      "moniker.spinnaker.io/application": "testapp",
+      "moniker.spinnaker.io/cluster": "statefulSet $name"
+    },
+    "creationTimestamp": "2018-10-28T19:13:07Z",
+    "generation": 1,
+    "labels": {
+      "app.kubernetes.io/managed-by": "spinnaker",
+      "app.kubernetes.io/name": "testapp"
+    },
+    "name": "$name",
+    "namespace": "$namespace",
+    "resourceVersion": "37483385",
+    "selfLink": "/apis/apps/v1/namespaces/$namespace/statefulsets/$name",
+    "uid": "80e2cc62-dae5-11e8-bcfc-0efba1451dfa"
+  },
+  "spec": {
+    "podManagementPolicy": "OrderedReady",
+    "replicas": $replicas,
+    "revisionHistoryLimit": 10,
+    "selector": {
+      "matchLabels": {
+        "app": "$name"
+      }
+    },
+    "serviceName": "$name-service",
+    "template": {
+      "metadata": {
+        "annotations": {
+          "artifact.spinnaker.io/location": "$namespace",
+          "artifact.spinnaker.io/name": "$name",
+          "artifact.spinnaker.io/type": "kubernetes/statefulSet",
+          "moniker.spinnaker.io/application": "testapp",
+          "moniker.spinnaker.io/cluster": "statefulSet $name"
+        },
+        "creationTimestamp": null,
+        "labels": {
+          "app": "$name",
+          "app.kubernetes.io/managed-by": "spinnaker",
+          "app.kubernetes.io/name": "testapp"
+        }
+      },
+      "spec": {
+        "affinity": {
+          "nodeAffinity": {
+            "requiredDuringSchedulingIgnoredDuringExecution": {
+              "nodeSelectorTerms": [
+                {
+                  "matchExpressions": [
+                    {
+                      "key": "node-role.kubernetes.io/testapp",
+                      "operator": "Exists"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "containers": [
+          {
+            "image": "testapp/$image:0.1",
+            "imagePullPolicy": "IfNotPresent",
+            "livenessProbe": {
+              "failureThreshold": 3,
+              "httpGet": {
+                "path": "/",
+                "port": 5000,
+                "scheme": "HTTP"
+              },
+              "initialDelaySeconds": 20,
+              "periodSeconds": 10,
+              "successThreshold": 1,
+              "timeoutSeconds": 2
+            },
+            "name": "testapp",
+            "ports": [
+              {
+                "containerPort": 5000,
+                "name": "http",
+                "protocol": "TCP"
+              }
+            ],
+            "readinessProbe": {
+              "failureThreshold": 3,
+              "httpGet": {
+                "path": "/",
+                "port": 5000,
+                "scheme": "HTTP"
+              },
+              "initialDelaySeconds": 20,
+              "periodSeconds": 10,
+              "successThreshold": 1,
+              "timeoutSeconds": 2
+            },
+            "resources": {},
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "volumeMounts": [
+              {
+                "mountPath": "/test",
+                "name": "$name"
+              }
+            ]
+          }
+        ],
+        "dnsPolicy": "ClusterFirst",
+        "restartPolicy": "Always",
+        "schedulerName": "default-scheduler",
+        "securityContext": {},
+        "terminationGracePeriodSeconds": 10,
+        "tolerations": []
+      }
+    },
+    "updateStrategy": {
+      "type": "RollingUpdate"
+    },
+    "volumeClaimTemplates": [
+      {
+        "metadata": {
+          "creationTimestamp": null,
+          "name": "$name"
+        },
+        "spec": {
+          "accessModes": [
+            "ReadWriteOnce"
+          ],
+          "resources": {
+            "requests": {
+              "storage": "1Gi"
+            }
+          },
+          "storageClassName": "standard"
+        },
+        "status": {
+          "phase": "Pending"
+        }
+      }
+    ]
+  }
+}

--- a/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/statefulsetpartitionbase.json
+++ b/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/statefulsetpartitionbase.json
@@ -1,0 +1,151 @@
+{
+    "apiVersion": "apps/v1",
+    "kind": "StatefulSet",
+    "metadata": {
+        "annotations": {
+            "artifact.spinnaker.io/location": "$namespace",
+            "artifact.spinnaker.io/name": "$name",
+            "artifact.spinnaker.io/type": "kubernetes/statefulSet",
+            "moniker.spinnaker.io/application": "testapp",
+            "moniker.spinnaker.io/cluster": "statefulSet $name"
+        },
+        "creationTimestamp": "2018-10-28T19:13:07Z",
+        "generation": 3,
+        "labels": {
+            "app.kubernetes.io/managed-by": "spinnaker",
+            "app.kubernetes.io/name": "testapp"
+        },
+        "name": "$name",
+        "namespace": "$namespace",
+        "resourceVersion": "37483385",
+        "selfLink": "/apis/apps/v1/namespaces/$namespace/statefulsets/$name",
+        "uid": "80e2cc62-dae5-11e8-bcfc-0efba1451dfa"
+    },
+    "spec": {
+        "podManagementPolicy": "OrderedReady",
+        "replicas": $replicas,
+        "revisionHistoryLimit": 10,
+        "selector": {
+            "matchLabels": {
+                "app": "$name"
+            }
+        },
+        "serviceName": "$name-service",
+        "template": {
+            "metadata": {
+                "annotations": {
+                    "artifact.spinnaker.io/location": "$namespace",
+                    "artifact.spinnaker.io/name": "$name",
+                    "artifact.spinnaker.io/type": "kubernetes/statefulSet",
+                    "moniker.spinnaker.io/application": "testapp",
+                    "moniker.spinnaker.io/cluster": "statefulSet $name"
+                },
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "$name",
+                    "app.kubernetes.io/managed-by": "spinnaker",
+                    "app.kubernetes.io/name": "testapp"
+                }
+            },
+            "spec": {
+                "affinity": {
+                    "nodeAffinity": {
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                            "nodeSelectorTerms": [
+                                {
+                                    "matchExpressions": [
+                                        {
+                                            "key": "node-role.kubernetes.io/testapp",
+                                            "operator": "Exists"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                },
+                "containers": [
+                    {
+                        "image": "testapp/$image:",
+                        "imagePullPolicy": "IfNotPresent",
+                        "livenessProbe": {
+                            "failureThreshold": 3,
+                            "httpGet": {
+                                "path": "/",
+                                "port": 5000,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 20,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 2
+                        },
+                        "name": "testapp",
+                        "ports": [
+                            {
+                                "containerPort": 5000,
+                                "name": "http",
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "readinessProbe": {
+                            "failureThreshold": 3,
+                            "httpGet": {
+                                "path": "/",
+                                "port": 5000,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 20,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 2
+                        },
+                        "resources": {},
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/test",
+                                "name": "$name"
+                            }
+                        ]
+                    }
+                ],
+                "dnsPolicy": "ClusterFirst",
+                "restartPolicy": "Always",
+                "schedulerName": "default-scheduler",
+                "securityContext": {},
+                "terminationGracePeriodSeconds": 10,
+                "tolerations": []
+            }
+        },
+        "updateStrategy": {
+            "rollingUpdate": {
+                "partition": $partition
+            },
+            "type": "RollingUpdate"
+        },
+        "volumeClaimTemplates": [
+            {
+                "metadata": {
+                    "creationTimestamp": null,
+                    "name": "$name"
+                },
+                "spec": {
+                    "accessModes": [
+                        "ReadWriteOnce"
+                    ],
+                    "resources": {
+                        "requests": {
+                            "storage": "1Gi"
+                        }
+                    },
+                    "storageClassName": "standard"
+                },
+                "status": {
+                    "phase": "Pending"
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
# Statefulset Partition roll out support

This PR adds support for statefulset partition roll outs. In order to do this with some confidence, we've added specs around the `KubernetesStatefulSetHandler` as well.

## Add specs for all scenarios

During this process a small bug was uncovered with `KubernetesManifest.isNewerThanObservedGeneration()`.

The `generation` and `observedGeneration` properties of `KubernetesManifest` are hydrated from YAML as integers at some point, so you end up with a `ClassCastException`, and that was being ignored, so the method ultimately returned true.

Note that these properties are integers according to the kubernetes API docs.

https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#objectmeta-v1-meta

https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#rollingupdatestatefulsetstrategy-v1-apps

## Add support for statefulset Partition roll out

The logic was taken directly from the kubectl code here
https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/rollout_status.go#L137-L146
c922c2f 

Looking for input on making sure I've covered everything.