### PR TITLE
perf(provider/kubernetes): Add chunk size option to get calls

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubectlJobExecutor.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubectlJobExecutor.java
@@ -509,6 +509,10 @@ public class KubectlJobExecutor {
     command.add("-o");
     command.add("json");
 
+    if (credentials.getKubectlGetChunkSize() != null) {
+     command.add("--chunk-size=" + credentials.getKubectlGetChunkSize());
+    }
+
     command.add("get");
     command.add(String.join(",", kind.stream().map(KubernetesKind::toString).collect(Collectors.toList())));
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
@@ -93,6 +93,9 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
   @Getter
   private final Integer kubectlRequestTimeoutSeconds;
 
+  @Getter
+  private final Integer kubectlGetChunkSize;
+
   // remove when kubectl is no longer a dependency
   @Getter
   private final String kubeconfigFile;
@@ -178,6 +181,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
     String context;
     String kubectlExecutable;
     Integer kubectlRequestTimeoutSeconds;
+    Integer kubectlGetChunkSize;
     String oAuthServiceAccount;
     List<String> oAuthScopes;
     String userAgent;
@@ -212,6 +216,11 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
 
     public Builder kubectlRequestTimeoutSeconds(Integer kubectlRequestTimeoutSeconds) {
       this.kubectlRequestTimeoutSeconds = kubectlRequestTimeoutSeconds;
+      return this;
+    }
+
+    public Builder kubectlGetChunkSize(Integer kubectlGetChunkSize) {
+      this.kubectlGetChunkSize = kubectlGetChunkSize;
       return this;
     }
 
@@ -317,6 +326,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
           kubeconfigFile,
           kubectlExecutable,
           kubectlRequestTimeoutSeconds,
+          kubectlGetChunkSize,
           context,
           oAuthServiceAccount,
           oAuthScopes,
@@ -341,6 +351,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
       String kubeconfigFile,
       String kubectlExecutable,
       Integer kubectlRequestTimeoutSeconds,
+      Integer kubectlGetChunkSize,
       String context,
       String oAuthServiceAccount,
       List<String> oAuthScopes,
@@ -362,6 +373,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
     this.debug = debug;
     this.kubectlExecutable = kubectlExecutable;
     this.kubectlRequestTimeoutSeconds = kubectlRequestTimeoutSeconds;
+    this.kubectlGetChunkSize = kubectlGetChunkSize;
     this.kubeconfigFile = kubeconfigFile;
     this.context = context;
     this.oAuthServiceAccount = oAuthServiceAccount;


### PR DESCRIPTION
`kubectl get` will chunk large responses by 500 by default. This PR lets you adjust, or disable that option (use 0). Disabling chunking increased the speed of `kubectl` calls by 50% in my testing against a large cluster. I am unsure the impact this will have at scale against the kubernetes api servers.

This property can be set per cluster, and only applies to get calls.
